### PR TITLE
add process.emit("metric")

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ var emitter = new Emitter({
 emitter.metric({ name: 'httpd.latency', value: 30 });
 emitter.metric({ name: 'disk.used.percent', value: 36 });
 emitter.metric({ name: 'heartbeat'});
+
+
+// if you don't have a reference to an emitter, you
+// can broadcast a metric to all extant emitters:
+process.emit('metric', { name: 'heartbeat' });
 ```
 
 See the `examples/` directory for working examples.

--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -12,6 +12,8 @@ var
 	os        = require('os')
 	;
 
+var emitters = [];
+
 var Emitter = module.exports = function Emitter(opts)
 {
 	if (this.constructor !== Emitter) return new Emitter(opts);
@@ -24,6 +26,7 @@ var Emitter = module.exports = function Emitter(opts)
 	if (opts.uri) Emitter.parseURI(opts);
 	if (opts.maxretries) this.maxretries = parseInt(opts.maxretries, 10);
 	if (opts.maxbacklog) this.maxbacklog = parseInt(opts.maxbacklog, 10);
+	if (emitters.indexOf(this) === -1) emitters.push(this);
 
 	this.options = opts;
 	this.defaults = { host: os.hostname() };
@@ -116,6 +119,8 @@ Emitter.prototype.connect = function connect()
 Emitter.prototype.destroy = function destroy()
 {
 	this.destroyed = true;
+	var idx = emitters.indexOf(this);
+	if (idx !== -1) { emitters.splice(idx, 1); }
 	if (!this.client) return;
 	this.output.unpipe();
 	this.client.removeAllListeners();
@@ -139,6 +144,8 @@ Emitter.prototype.onClose = function onClose(reason)
 {
 	this.ready = false;
 	this.retries++;
+	var idx = emitters.indexOf(this);
+	if (idx !== -1) { emitters.splice(idx, 1); }
 	if (this.retries <= this.maxretries) {
 		var t = setTimeout(this.connect.bind(this), this.nextBackoff());
 		t.unref()
@@ -193,4 +200,14 @@ function createSerializer()
 	};
 
 	return transformer;
+}
+
+process.on('metric', onmetric);
+
+function onmetric (metric)
+{
+	for (var i = 0; i < emitters.length; ++i)
+	{
+		emitters[i].metric(metric);
+	}
 }


### PR DESCRIPTION
Allows folks to emit metrics without having a direct reference to an `Emitter` object. If no `Emitter`s are extant, `process.emit('metric')` is a no-op, which is nice!