### PR TITLE
Move the JSON stringifier to a separate file

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -1,15 +1,15 @@
 var
-	stream    = require('readable-stream'),
-	discard   = require('discard-stream'),
-	UDPStream = require('./udp-stream'),
-	WSStream  = require('./ws-stream'),
-	_         = require('lodash'),
-	events    = require('events'),
-	assert    = require('assert'),
-	util      = require('util'),
-	url       = require('url'),
-	net       = require('net'),
-	os        = require('os')
+	discard             = require('discard-stream'),
+	UDPStream           = require('./udp-stream'),
+	WSStream            = require('./ws-stream'),
+	JSONStringifyStream = require('./json-stringify-stream'),
+	_                   = require('lodash'),
+	events              = require('events'),
+	assert              = require('assert'),
+	util                = require('util'),
+	url                 = require('url'),
+	net                 = require('net'),
+	os                  = require('os')
 	;
 
 var emitters = [];
@@ -24,8 +24,8 @@ var Emitter = module.exports = function Emitter(opts)
 	events.EventEmitter.call(this);
 
 	if (opts.uri) Emitter.parseURI(opts);
-	if (opts.maxretries) this.maxretries = parseInt(opts.maxretries, 10);
-	if (opts.maxbacklog) this.maxbacklog = parseInt(opts.maxbacklog, 10);
+	if (opts.maxretries) this.maxretries = opts.maxretries;
+	if (opts.maxbacklog) this.maxbacklog = opts.maxbacklog;
 	if (emitters.indexOf(this) === -1) emitters.push(this);
 
 	this.options = opts;
@@ -33,14 +33,13 @@ var Emitter = module.exports = function Emitter(opts)
 	if (opts.node) this.defaults.node = opts.node;
 	this.app = opts.app;
 	this.input = discard({objectMode: true, maxBacklog: opts.maxbacklog});
-	this.output = createSerializer();
+	this.output = JSONStringifyStream({ highWaterMark: opts.maxbacklog });
 	this.input.pipe(this.output);
 	this.connect();
 };
 util.inherits(Emitter, events.EventEmitter);
 
 Emitter.prototype.defaults   = null;
-Emitter.prototype.maxbacklog = 1000;
 Emitter.prototype.client     = null;
 Emitter.prototype.ready      = false;
 Emitter.prototype.retries    = 0;
@@ -184,23 +183,6 @@ Emitter.prototype.metric = function metric(attrs)
 	this.input.write(ev);
 	return ev;
 };
-
-function createSerializer()
-{
-	var opts = {
-		readableObjectMode: false,
-		writableObjectMode: true,
-		highWaterMark: 0
-	};
-	var transformer = new stream.Transform(opts);
-
-	transformer._transform = function(chunk, enc, ready)
-	{
-		return ready(null, JSON.stringify(chunk) + '\n');
-	};
-
-	return transformer;
-}
 
 process.on('metric', onmetric);
 

--- a/lib/json-stringify-stream.js
+++ b/lib/json-stringify-stream.js
@@ -1,0 +1,20 @@
+var 
+	stream = require('readable-stream')
+	;
+
+module.exports = function createSerializer(options)
+{
+	var opts = {
+		readableObjectMode: false,
+		writableObjectMode: true,
+		highWaterMark: options.highWaterMark
+	};
+	var transformer = new stream.Transform(opts);
+
+	transformer._transform = function(chunk, enc, ready)
+	{
+		return ready(null, JSON.stringify(chunk) + '\n');
+	};
+
+	return transformer;
+};


### PR DESCRIPTION
Set the `highWaterMark` of the stringifier to our maximum backlog.
Don't `parseInt` options which are supposed to be integers in the first
place.