### PR TITLE
adding setGlobalEmitter

### DIFF
--- a/test.js
+++ b/test.js
@@ -482,9 +482,11 @@ describe('numbat-emitter', function()
 
 	describe('process.emit("metric")', function()
 	{
-		it('calls metric() on all extant emitters', function(done)
+		it('calls metric() on global emitter', function(done)
 		{
 			var emitter = new Emitter(mockUDPOpts);
+                        Emitter.setGlobalEmitter(emitter);
+
 			var expect = {name: 'example'};
 			var seen = null;
 			emitter.metric = function(xs)
@@ -498,78 +500,41 @@ describe('numbat-emitter', function()
 
 		it('skips destroyed emitters', function(done)
 		{
-			var emitter = new Emitter(mockUDPOpts);
-			var emitter2 = new Emitter(mockUDPOpts);
+
 			var expect = {name: 'example'};
-			var seen = null;
-			emitter.metric = function(xs)
-			{
-				seen = xs;
-			};
-			emitter2.metric = function()
+			var emitter = new Emitter(mockUDPOpts);
+                        Emitter.setGlobalEmitter(emitter);
+
+			emitter.metric = function()
 			{
 				throw new Error('should not reach this point');
 			};
-			emitter2.destroy();
+			emitter.destroy();
 			process.emit('metric', expect);
-			seen.must.equal(expect);
 			done();
 		});
 
 		it('skips closed emitters', function(done)
 		{
-			var emitter = new Emitter(mockUDPOpts);
-			var emitter2 = new Emitter(mockOpts);
+			var emitter = new Emitter(mockOpts);
 			var expect = {name: 'example'};
-			var seen = null;
-			emitter.metric = function(xs)
-			{
-				seen = xs;
-			};
-			emitter2.metric = function()
+                        Emitter.setGlobalEmitter(emitter);
+			emitter.metric = function()
 			{
 				throw new Error('should not reach this point');
 			};
-			emitter2.connect();
-			emitter2.on('ready', function()
+			emitter.connect();
+			emitter.on('ready', function()
 			{
-				emitter2.client.destroy();
-				emitter2.on('close', function()
+				emitter.client.destroy();
+				emitter.on('close', function()
 				{
 					process.emit('metric', expect);
-					demand(seen).equal(expect);
 					done();
 				});
 			});
 		});
 
-		it('repeated destroy does not affect other emitters', function(done)
-		{
-			var emitter = new Emitter(mockUDPOpts);
-			var emitter2 = new Emitter(mockOpts);
-			var expect = {name: 'example'};
-			var seen = null;
-			emitter.metric = function(xs)
-			{
-				seen = xs;
-			};
-			emitter2.metric = function()
-			{
-				throw new Error('should not reach this point');
-			};
-			emitter2.connect();
-			emitter2.on('ready', function()
-			{
-				emitter2.client.destroy();
-				emitter2.on('close', function()
-				{
-					emitter2.destroy();
-					process.emit('metric', expect);
-					demand(seen).equal(expect);
-					done();
-				});
-			});
-		});
 	});
 
 	after(function(done)


### PR DESCRIPTION
this changes the behavior of having every active emitter receive process.emit metrics

only the globalEmitter will get metrics from process.emit('metric') and it must be explicitly set as the global emitter with Emitter.setGlobalEmitter(emitter) 