### PR TITLE
Run tests on a wider range of node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: node_js
 node_js:
     - "0.10"
     - '4.2'
+    - '4.3'
     - '5.1'
+    - '5.2'
+    - '5.3'
+    - '5.4'
+    - '5.5'
+    - '5.6'
 script:
     - npm run test-travis
 sudo: false


### PR DESCRIPTION
Make sure its all green on newer node versions. 

The number of 5.x versions are perhaps a bit overkill. Maybe the tests should run just on latest non LTS versions.