### PR TITLE
feature: nsq output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ emitter.metric({ name: 'disk.used.percent', value: 36 });
 emitter.metric({ name: 'heartbeat'});
 
 // if you don't have a reference to an emitter, you
-// can broadcast a metric to all extant emitters:
+// can broadcast a metric to a global emitter:
+Emitter.setGlobalEmitter(emitter);
 process.emit('metric', { name: 'heartbeat' });
 ```
 
@@ -27,7 +28,7 @@ See the `examples/` directory for working examples.
 
 ## Configuration
 
-The constructor requires an options object with an app name in the `app` field and some manner of specifying where to emit the metrics. You can specify the protocol, host, and port in handy url-parseable format: `tcp://collector.example.com:5000`, `udp://localhost:5000`, `socket:/tmp/foozle.sock`, `ws://localhost:5000`. Do this in the `uri` field of the options object.
+The constructor requires an options object with an app name in the `app` field and some manner of specifying where to emit the metrics. You can specify the protocol, host, and port in handy url-parseable format: `tcp://collector.example.com:5000`, `udp://localhost:5000`, `socket:/tmp/foozle.sock`, `ws://localhost:5000`, `nsq://nsqd.example.com:4151` Do this in the `uri` field of the options object.
 
 Config options:
 
@@ -62,6 +63,8 @@ Or numbat might be listening via a unix domain socket:
     app: 'socket-emitter'
 }
 ```
+
+For complete working emitters, see the [examples directory](examples/).
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ emitter.metric({ name: 'httpd.latency', value: 30 });
 emitter.metric({ name: 'disk.used.percent', value: 36 });
 emitter.metric({ name: 'heartbeat'});
 
-
 // if you don't have a reference to an emitter, you
 // can broadcast a metric to all extant emitters:
 process.emit('metric', { name: 'heartbeat' });

--- a/examples/nsq-emitter.js
+++ b/examples/nsq-emitter.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+var Emitter = require('../index');
+
+var emitter = new Emitter({
+	uri: 'nsq://localhost:4151/pub',
+	app: 'example-nsq',
+	topic: 'test',
+});
+Emitter.setGlobalEmitter(emitter);
+
+process.emit('metric', { name: 'start', pid: process.pid });
+
+function heartbeat()
+{
+	console.log('heartbeat');
+	process.emit('metric', { name: 'heartbeat', ttl: 16000 });
+}
+
+function resources()
+{
+	console.log('emitting 3 memory metrics');
+	var mem = process.memoryUsage();
+
+	process.emit('metric', { name: 'memory.rss', value: mem.rss });
+	process.emit('metric', { name: 'memory.heapTotal', value: mem.heapTotal });
+	process.emit('metric', { name: 'memory.heapUsed', value: mem.heapUsed });
+}
+
+var heartbeatTimer = setInterval(heartbeat, 15000);
+var resourcesTimer = setInterval(resources, 30000);
+
+process.on('SIGINT', function()
+{
+	console.log('Shutting down gracefully.');
+	clearInterval(heartbeatTimer);
+	clearInterval(resourcesTimer);
+	process.emit('metric', { name: 'shutdown' });
+	setTimeout(process.exit, 500);
+});

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ Emitter.prototype.maxbacklog  = 1000;
 Emitter.prototype.shouldUnref = true;
 
 Object.defineProperty(Emitter.prototype, 'backlog', {
-	get: function backlogGetter() { return this.input.backlog; }
+	get: function get() { return this.input.backlog; }
 });
 
 Emitter.setGlobalEmitter = function setGlobalEmitter(emitter)

--- a/lib/nsq-stream.js
+++ b/lib/nsq-stream.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const
+	path    = require('path'),
+	Request = require('request'),
+	stream  = require('readable-stream'),
+	util    = require('util')
+	;
+
+const NSQStream = module.exports = function NSQStream(opts)
+{
+	stream.Writable.call(this);
+
+	if (!opts.uri.match(/\/put$/))
+		opts.uri = path.join(opts.uri, 'put');
+
+	this.defaults = {
+		uri: opts.uri,
+		method: 'post',
+		qs: { topic: opts.topic || 'metrics' },
+	};
+	process.nextTick(this.emit.bind(this, 'connect')); // because our socket sure won't!
+};
+util.inherits(NSQStream, stream.Writable);
+
+NSQStream.prototype._write = function _write(event, encoding, callback)
+{
+	const options = Object.assign({ body: JSON.stringify(event) }, this.defaults);
+	Request(options, function(err, response, body)
+	{
+		callback(err);
+	});
+};

--- a/lib/nsq-stream.js
+++ b/lib/nsq-stream.js
@@ -11,15 +11,15 @@ const NSQStream = module.exports = function NSQStream(opts)
 {
 	stream.Writable.call(this);
 
-	if (!opts.uri.match(/\/put$/))
-		opts.uri = path.join(opts.uri, 'put');
+	opts.parsed.protocol = 'http:';
+	if (!opts.parsed.pathname) opts.parsed.pathname = 'put';
 
 	this.defaults = {
-		uri: opts.uri,
+		uri: opts.parsed.format(),
 		method: 'post',
 		qs: { topic: opts.topic || 'metrics' },
 	};
-	process.nextTick(this.emit.bind(this, 'connect')); // because our socket sure won't!
+	process.nextTick(this.emit.bind(this, 'connect')); // we won't emit the event otherwise
 };
 util.inherits(NSQStream, stream.Writable);
 

--- a/lib/nsq-stream.js
+++ b/lib/nsq-stream.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const
-	path    = require('path'),
 	Request = require('request'),
 	stream  = require('readable-stream'),
 	util    = require('util')
@@ -12,7 +11,7 @@ const NSQStream = module.exports = function NSQStream(opts)
 	stream.Writable.call(this);
 
 	opts.parsed.protocol = 'http:';
-	if (!opts.parsed.pathname) opts.parsed.pathname = 'put';
+	if (!opts.parsed.pathname) opts.parsed.pathname = 'pub';
 
 	this.defaults = {
 		uri: opts.parsed.format(),
@@ -25,9 +24,12 @@ util.inherits(NSQStream, stream.Writable);
 
 NSQStream.prototype._write = function _write(event, encoding, callback)
 {
-	const options = Object.assign({ body: JSON.stringify(event) }, this.defaults);
+	const options = Object.assign({ body: event }, this.defaults);
 	Request(options, function(err, response, body)
 	{
-		callback(err);
+		if (err) return callback(err);
+		if (response.statusCode !== 200)
+			return callback(new Error(`unexpected status code ${response.statusCode}`));
+		callback();
 	});
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "discard-stream": "^1.0.1",
     "lodash": "~4.17.4",
     "readable-stream": "~2.2.3",
+    "request": "~2.80.0",
     "ws": "~2.2.0"
   },
   "devDependencies": {
@@ -40,8 +41,8 @@
     "lint": "xo",
     "test": "nyc mocha -t 5000 --check-leaks --ui exports -R spec test.js",
     "travis": "npm run lint && npm test"
-    },
-    "xo": {
-      "extends": "eslint-config-ceejbot"
-    }
+  },
+  "xo": {
+    "extends": "eslint-config-ceejbot"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "xo",
-    "test": "nyc mocha -t 5000 --check-leaks --ui exports -R spec test.js",
+    "test": "nyc mocha -t 5000 --check-leaks -R spec test/",
     "travis": "npm run lint && npm test"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -7,21 +7,20 @@
     "url": "https://github.com/numbat-metrics/numbat-emitter/issues"
   },
   "dependencies": {
-    "coveralls": "~2.12.0",
     "discard-stream": "^1.0.1",
     "lodash": "~4.17.4",
-    "readable-stream": "~2.2.3",
-    "request": "~2.80.0",
-    "ws": "~2.2.0"
+    "readable-stream": "~2.2.9",
+    "request": "~2.81.0",
+    "ws": "~2.2.3"
   },
   "devDependencies": {
-    "coveralls": "~2.11.14",
-    "eslint-config-ceejbot": "~1.0.3",
+    "coveralls": "~2.13.0",
+    "eslint-config-ceejbot": "~1.0.4",
     "json-stream": "1.*",
     "mocha": "~3.2.0",
     "must": "~0.13.4",
-    "nyc": "~10.1.2",
-    "xo": "~0.17.1"
+    "nyc": "~10.2.0",
+    "xo": "~0.18.1"
   },
   "homepage": "https://github.com/numbat-metrics/numbat-emitter",
   "keywords": [
@@ -43,6 +42,9 @@
     "travis": "npm run lint && npm test"
   },
   "xo": {
-    "extends": "eslint-config-ceejbot"
+    "extends": "eslint-config-ceejbot",
+    "rules": {
+      "prefer-arrow-callback": 0
+    }
   }
 }

--- a/test.js
+++ b/test.js
@@ -14,8 +14,7 @@ var
 describe('numbat-emitter', function()
 {
 	var mockOpts = {
-		host: 'localhost',
-		port: 4333,
+		uri: 'tcp://localhost:4333',
 		app: 'testapp',
 		node: 'node-1'
 	};
@@ -128,24 +127,11 @@ describe('numbat-emitter', function()
 			done();
 		});
 
-		it('requires a host & port option', function(done)
+		it('requires at least one of path or uri', function(done)
 		{
-			function shouldThrow() { return new Emitter({ host: 'example.com' }); }
-			shouldThrow.must.throw(/host/);
+			function shouldThrow() { return new Emitter({ }); }
+			shouldThrow.must.throw(/output uri or/);
 			done();
-		});
-
-		it('requires a path option otherwise', function(done)
-		{
-			function shouldThrow() { return new Emitter({ path: '/tmp/numbat.sock' }); }
-			shouldThrow.must.throw(/app/);
-			done();
-		});
-
-		it('requires an app name option', function()
-		{
-			function shouldThrow() { return new Emitter({ host: 'localhost', port: 4000 }); }
-			shouldThrow.must.throw(/app/);
 		});
 
 		it('can be constructed', function(done)
@@ -155,7 +141,8 @@ describe('numbat-emitter', function()
 
 			emitter.must.have.property('options');
 			emitter.options.must.be.an.object();
-			emitter.options.must.equal(mockOpts);
+			emitter.options.host.must.equal('localhost');
+			emitter.options.port.must.equal('4333');
 
 			emitter.must.have.property('defaults');
 			emitter.defaults.must.be.an.object();
@@ -173,6 +160,13 @@ describe('numbat-emitter', function()
 			e.must.have.property('options');
 			e.options.must.not.have.property('uri');
 			e.options.must.have.property('path');
+		});
+
+		it('defaults `app` to `numbat`', function()
+		{
+			var e = new Emitter({ uri: 'sock:/tmp/foobar.sock' });
+			e.must.have.property('app');
+			e.app.must.equal('numbat');
 		});
 
 		it('adds the host name to its default fields', function()

--- a/test/01-parse-uri.js
+++ b/test/01-parse-uri.js
@@ -1,0 +1,64 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand  = require('must'),
+	Emitter = require('../index')
+	;
+
+describe('createClient()', function()
+{
+	it('parses the tcp uri option', function(done)
+	{
+		var opts = { uri: 'tcp://localhost:5000', app: 'foo'};
+		var e = new Emitter(opts);
+		e.options.host.must.equal('localhost');
+		e.options.port.must.equal('5000');
+		done();
+	});
+
+	it('parses the udp uri option', function(done)
+	{
+		var opts = { uri: 'udp://localhost:5000', app: 'foo'};
+		var e = new Emitter(opts);
+		e.options.host.must.equal('localhost');
+		e.options.port.must.equal('5000');
+		done();
+	});
+
+	it('parses the socket uri option', function()
+	{
+		var opts = { uri: 'socket:/tmp/foo.sock', app: 'foo'};
+		var e = new Emitter(opts);
+		e.options.path.must.equal('/tmp/foo.sock');
+	});
+
+	it('parses the ws uri option', function(done)
+	{
+		var opts = { uri: 'ws://localhost:5000', app: 'foo'};
+		var e = new Emitter(opts);
+		e.options.url.hostname.must.equal('localhost');
+		e.options.url.port.must.equal('5000');
+		e.options.must.not.have.property('udp');
+		done();
+	});
+
+	it('parses the wss (secure) uri option', function(done)
+	{
+		var opts = { uri: 'wss://localhost:5000', app: 'foo'};
+		var e = new Emitter(opts);
+		e.options.url.hostname.must.equal('localhost');
+		e.options.url.port.must.equal('5000');
+		e.options.must.not.have.property('udp');
+		done();
+	});
+
+	it('throws when given an unsupported uri', function()
+	{
+		function shouldThrow()
+		{
+			return new Emitter({ uri: 'http://example.com', app: 'foo'});
+		}
+		shouldThrow.must.throw(/unsupported destination uri/);
+	});
+});

--- a/test/02-constructor.js
+++ b/test/02-constructor.js
@@ -1,0 +1,92 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand  = require('must'),
+	os      = require('os'),
+	Emitter = require('../index')
+	;
+
+describe('constructor', function(done)
+{
+	var mockOpts = {
+		uri: 'tcp://localhost:4333',
+		app: 'testapp',
+		node: 'node-1'
+	};
+
+	var mockUDPOpts = {
+		uri: 'udp://localhost:4334',
+		app: 'testapp',
+	};
+
+	it('requires an options object', function(done)
+	{
+		function shouldThrow() { return new Emitter(); }
+		shouldThrow.must.throw(/options/);
+		done();
+	});
+
+	it('requires at least one of path or uri', function(done)
+	{
+		function shouldThrow() { return new Emitter({ }); }
+		shouldThrow.must.throw(/output uri or/);
+		done();
+	});
+
+	it('can be constructed', function(done)
+	{
+		var emitter = new Emitter(mockOpts);
+		emitter.must.be.an.object();
+
+		emitter.must.have.property('options');
+		emitter.options.must.be.an.object();
+		emitter.options.host.must.equal('localhost');
+		emitter.options.port.must.equal('4333');
+
+		emitter.must.have.property('defaults');
+		emitter.defaults.must.be.an.object();
+
+		emitter.must.have.property('backlog');
+		emitter.backlog.must.be.an.array();
+
+		emitter.destroy();
+		done();
+	});
+
+	it('calls parseURI() when given a uri option', function()
+	{
+		var e = new Emitter({ uri: 'sock:/tmp/foobar.sock', app: 'test' });
+		e.must.have.property('options');
+		e.options.must.have.property('path');
+	});
+
+	it('defaults `app` to `numbat`', function()
+	{
+		var e = new Emitter({ uri: 'sock:/tmp/foobar.sock' });
+		e.must.have.property('app');
+		e.app.must.equal('numbat');
+	});
+
+	it('adds the host name to its default fields', function()
+	{
+		var e = new Emitter({ uri: 'sock:/tmp/foobar.sock', app: 'test' });
+		e.defaults.must.have.property('host');
+		e.defaults.host.must.equal(os.hostname());
+	});
+
+	it('has some global emitter functions and stuff', function()
+	{
+		Emitter.must.have.property('setGlobalEmitter');
+		Emitter.setGlobalEmitter.must.be.a.function();
+		Emitter.must.have.property('getGlobalEmitter');
+		Emitter.getGlobalEmitter.must.be.a.function();
+
+		var first = Emitter.getGlobalEmitter();
+		demand(first).be.falsy();
+		var emitter = new Emitter(mockUDPOpts);
+		Emitter.setGlobalEmitter(emitter);
+		Emitter.getGlobalEmitter().must.equal(emitter);
+		Emitter.setGlobalEmitter();
+	});
+});

--- a/test/03-connections.js
+++ b/test/03-connections.js
@@ -1,0 +1,131 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand     = require('must'),
+	dgram      = require('dgram'),
+	net        = require('net'),
+	Emitter    = require('../index'),
+	JSONStream = require('json-stream')
+	;
+
+describe('connections', function()
+{
+	var mockOpts = {
+		uri: 'tcp://localhost:4333',
+		app: 'testapp',
+		node: 'node-1'
+	};
+
+	var mockServer, mockUDPServer;
+
+	before(function(done)
+	{
+		var count = 0;
+		function onConnection(socket)
+		{
+			var instream = new JSONStream();
+			socket.pipe(instream);
+			instream.on('data', function(data)
+			{
+				mockServer.emit('received', data);
+			});
+		}
+
+		mockServer = net.createServer(onConnection);
+		mockServer.listen(4333, function()
+		{
+			count++;
+			if (count === 2) done();
+		});
+
+		mockUDPServer = dgram.createSocket('udp4');
+		mockUDPServer.on('listening', function()
+		{
+			count++;
+			if (count === 2) done();
+		});
+		mockUDPServer.on('message', function(msg, rinfo)
+		{
+			mockUDPServer.emit('received', JSON.parse(msg));
+		});
+		mockUDPServer.bind(4334);
+	});
+
+	it('calls connect() when constructed', function(done)
+	{
+		var emitter = Emitter(mockOpts);
+		emitter.must.have.property('client');
+		emitter.client.on('connect', function()
+		{
+			emitter.destroy();
+			done();
+		});
+	});
+
+	it('allows connect() to be called twice safely', function(done)
+	{
+		var emitter = new Emitter(mockOpts);
+		emitter.client.on('connect', function()
+		{
+			emitter.connect();
+			emitter.destroy();
+			done();
+		});
+	});
+
+	it('allows destroy() to be called twice safely', function(done)
+	{
+		var emitter = new Emitter(mockOpts);
+		emitter.client.on('connect', function()
+		{
+			emitter.destroy();
+			emitter.destroy();
+			done();
+		});
+	});
+
+	it('adds listeners for `connect`, `error`, and `close`', function(done)
+	{
+		var emitter = new Emitter(mockOpts);
+		var listeners = emitter.client.listeners('connect');
+		listeners.must.be.an.array();
+		listeners.length.must.be.above(0);
+
+		listeners = emitter.client.listeners('error');
+		listeners.must.be.an.array();
+		listeners.length.must.be.above(0);
+
+		listeners = emitter.client.listeners('close');
+		listeners.must.be.an.array();
+		listeners.length.must.be.above(0);
+
+		emitter.destroy();
+
+		done();
+	});
+
+	it('reconnects on close', function(done)
+	{
+		var count = 0;
+		var emitter = new Emitter(mockOpts);
+		emitter.on('ready', function()
+		{
+			count++;
+			if (count === 2)
+			{
+				emitter.destroy();
+				done();
+			}
+		});
+
+		emitter.client.end();
+	});
+
+	after(function(done)
+	{
+		mockUDPServer.close();
+		mockServer.close();
+		done();
+	});
+});

--- a/test/04-emitting-metrics.js
+++ b/test/04-emitting-metrics.js
@@ -1,0 +1,242 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand     = require('must'),
+	stream     = require('readable-stream'),
+	dgram      = require('dgram'),
+	net        = require('net'),
+	Emitter    = require('../index'),
+	JSONStream = require('json-stream')
+	;
+
+describe('metric()', function()
+{
+	var mockOpts = {
+		uri: 'tcp://localhost:4333',
+		app: 'testapp',
+		node: 'node-1'
+	};
+
+	var mockUDPOpts = {
+		uri: 'udp://localhost:4334',
+		app: 'testapp',
+	};
+
+	var mockServer, mockUDPServer;
+
+	before(function(done)
+	{
+		var count = 0;
+		function onConnection(socket)
+		{
+			var instream = new JSONStream();
+			socket.pipe(instream);
+			instream.on('data', function(data)
+			{
+				mockServer.emit('received', data);
+			});
+		}
+
+		mockServer = net.createServer(onConnection);
+		mockServer.listen(4333, function()
+		{
+			count++;
+			if (count === 2) done();
+		});
+
+		mockUDPServer = dgram.createSocket('udp4');
+		mockUDPServer.on('listening', function()
+		{
+			count++;
+			if (count === 2) done();
+		});
+		mockUDPServer.on('message', function(msg, rinfo)
+		{
+			mockUDPServer.emit('received', JSON.parse(msg));
+		});
+		mockUDPServer.bind(4334);
+	});
+
+	describe('via metric()', function()
+	{
+		it('requires that an object be passed to metric()', function(done)
+		{
+			var emitter = new Emitter(mockOpts);
+			function shouldThrow() { emitter.metric(); }
+			shouldThrow.must.throw(/empty event/);
+			done();
+		});
+
+		it('requires a `name` field for all metrics', function(done)
+		{
+			var emitter = new Emitter(mockOpts);
+			function shouldThrow() { emitter.metric({ foo: 'bar' }); }
+			shouldThrow.must.throw(/name/);
+			done();
+		});
+
+		it('supplies a value of 1 if one is not provided', function(done)
+		{
+			function observer(d)
+			{
+				d.must.be.an.object();
+				d.must.have.property('value');
+				d.value.must.equal(1);
+				mockServer.removeListener('received', observer);
+				done();
+			}
+
+			mockServer.on('received', observer);
+			var emitter = new Emitter(mockOpts);
+			emitter.metric({ name: 'test' });
+		});
+
+		it('returns the metric it makes for your curiosity', function()
+		{
+			var emitter = new Emitter(mockUDPOpts);
+			var obj = emitter.metric({ name: 'returnme' });
+			obj.must.be.an.object();
+			obj.name.must.equal('testapp.returnme');
+			obj.must.have.property('host');
+			obj.must.not.have.property('node');
+		});
+
+		it('writes event objects to its socket', function(done)
+		{
+			function observer(d)
+			{
+				d.must.be.an.object();
+				d.must.have.property('host');
+				d.must.have.property('time');
+				d.must.have.property('node');
+				d.node.must.equal('node-1');
+				d.value.must.equal(4);
+				d.name.must.equal('testapp.test');
+				mockServer.removeListener('received', observer);
+				done();
+			}
+
+			mockServer.on('received', observer);
+			var emitter = new Emitter(mockOpts);
+			emitter.metric({ name: 'test', value: 4 });
+		});
+
+		it('does not override the time field when present', function(done)
+		{
+			function observer(d)
+			{
+				d.must.be.an.object();
+				d.must.have.property('time');
+				d.time.toString().must.equal('2014-01-01T00:00:00.000Z');
+				mockServer.removeListener('received', observer);
+				done();
+			}
+
+			mockServer.on('received', observer);
+			var emitter = new Emitter(mockOpts);
+			emitter.metric({ name: 'test', value: 4, time: new Date('2014-01-01') });
+		});
+
+		it('events are preserved until reconnected', function(done)
+		{
+			this.timeout(5000);
+
+			var emitter = new Emitter(mockOpts);
+			emitter.on('close', function()
+			{
+				emitter.metric({ name: 'test.splort', value: 4 });
+				emitter.metric({ name: 'test.latency', value: 30 });
+				var ws = new stream.Writable();
+				var acc = [];
+				ws._write = function(chunk, enc, cb)
+				{
+					acc.push(chunk);
+					cb();
+				};
+				ws.once('finish', function()
+				{
+					var items = Buffer.concat(acc)
+						.toString('utf8')
+						.split('\n')
+						.slice(0, -1)
+						.map(JSON.parse);
+					items.must.be.an.array();
+					items.length.must.equal(2);
+					items[0].must.have.property('name');
+					items[0].name.must.equal('testapp.test.splort');
+					done();
+				});
+				emitter.output.pipe(ws);
+				emitter.input.end();
+			});
+
+			emitter.connect = function() {};
+			emitter.client.end();
+		});
+	});
+
+	describe('via process.emit("metric")', function()
+	{
+		it('calls metric() on global emitter', function(done)
+		{
+			var emitter = new Emitter(mockUDPOpts);
+			Emitter.setGlobalEmitter(emitter);
+
+			var expect = {name: 'example'};
+			var seen = null;
+			emitter.metric = function(xs)
+			{
+				seen = xs;
+			};
+			process.emit('metric', expect);
+			demand(seen).equal(expect);
+			done();
+		});
+
+		it('skips destroyed emitters', function(done)
+		{
+
+			var expect = {name: 'example'};
+			var emitter = new Emitter(mockUDPOpts);
+			Emitter.setGlobalEmitter(emitter);
+
+			emitter.metric = function()
+			{
+				throw new Error('should not reach this point');
+			};
+			emitter.destroy();
+			process.emit('metric', expect);
+			done();
+		});
+
+		it('skips closed emitters', function(done)
+		{
+			var emitter = new Emitter(mockOpts);
+			emitter.maxretries = 0;
+			var expect = {name: 'example'};
+			Emitter.setGlobalEmitter(emitter);
+			emitter.metric = function()
+			{
+				throw new Error('should not reach this point');
+			};
+			emitter.connect();
+			emitter.on('ready', function()
+			{
+				emitter.client.destroy();
+				emitter.on('close', function()
+				{
+					process.emit('metric', expect);
+					done();
+				});
+			});
+		});
+	});
+
+	after(function(done)
+	{
+		mockServer.close();
+		mockUDPServer.close();
+		done();
+	});
+});

--- a/test/05-backpressure.js
+++ b/test/05-backpressure.js
@@ -1,0 +1,114 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand     = require('must'),
+	net        = require('net'),
+	Emitter    = require('../index'),
+	JSONStream = require('json-stream')
+	;
+
+describe('backpressure', function()
+{
+	var mockOpts = {
+		uri: 'tcp://localhost:4335',
+		app: 'testapp',
+		node: 'node-1',
+	};
+
+	var mockServer;
+
+	before(function(done)
+	{
+		function onConnection(socket)
+		{
+			var instream = new JSONStream();
+			socket.pipe(instream);
+			instream.on('data', function(data)
+			{
+				mockServer.emit('received', data);
+			});
+		}
+
+		mockServer = net.createServer(onConnection);
+		mockServer.listen(4335, done);
+	});
+
+	it('sends its backlog when connected', function(done)
+	{
+		var count = 0;
+		function observer(d)
+		{
+			count++;
+			if (count === 1)
+				d.name.must.equal('testapp.test.splort');
+
+			if (count === 2)
+			{
+				d.name.must.equal('testapp.test.latency');
+				mockServer.removeListener('received', observer);
+				emitter.destroy();
+				done();
+			}
+		}
+		mockServer.on('received', observer);
+
+		var emitter = new Emitter(mockOpts);
+
+		function fillBacklog()
+		{
+			emitter.removeListener('close', fillBacklog);
+			emitter.metric({ name: 'test.splort', value: 4 });
+			emitter.metric({ name: 'test.latency', value: 30 });
+		}
+
+		emitter.on('close', fillBacklog);
+		var orig = emitter.connect.bind(emitter);
+		emitter.connect = function() { setTimeout(orig, 300); };
+		emitter.client.end();
+	});
+
+	it('sends normally when connected', function(done)
+	{
+		var emitter = new Emitter(mockOpts);
+		emitter.on('ready', function()
+		{
+			emitter.metric({ name: 'testapp.splort', value: 4 });
+			emitter.metric({ name: 'testapp.latency', value: 30 });
+		});
+
+		var count = 0;
+		function observer(d)
+		{
+			count++;
+			switch (count)
+			{
+			case 1:
+				d.name.must.equal('testapp.splort');
+				break;
+			case 2:
+				d.name.must.equal('testapp.latency');
+				mockServer.removeListener('received', observer);
+				emitter.destroy();
+				done();
+				break;
+			}
+		}
+		mockServer.on('received', observer);
+
+		emitter.connect();
+	});
+
+	it('destroy can be safely called before connect', function(done)
+	{
+		var emitter = new Emitter(mockOpts);
+		emitter.destroy();
+		done();
+	});
+
+	after(function(done)
+	{
+		mockServer.close();
+		process.nextTick(done);
+	});
+});

--- a/test/06-udp.js
+++ b/test/06-udp.js
@@ -1,0 +1,64 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand     = require('must'),
+	dgram      = require('dgram'),
+	Emitter    = require('../index')
+	;
+
+describe('udp output', function()
+{
+	const mockUDPOpts = {
+		uri: 'udp://localhost:4334',
+		app: 'testapp',
+	};
+
+	var mockUDPServer;
+
+	before(function(done)
+	{
+		mockUDPServer = dgram.createSocket('udp4');
+		mockUDPServer.on('listening', done);
+		mockUDPServer.on('message', function(msg, rinfo)
+		{
+			mockUDPServer.emit('received', JSON.parse(msg));
+		});
+		mockUDPServer.bind(4334);
+	});
+
+	it('can construct a UDP emitter', function(done)
+	{
+		var emitter = new Emitter(mockUDPOpts);
+		emitter.on('ready', function()
+		{
+			emitter.client.constructor.name.must.equal('UDPStream');
+			done();
+		});
+		emitter.connect();
+	});
+
+	it('writes event objects to its socket over udp', function(done)
+	{
+		function observer(d)
+		{
+			d.must.be.an.object();
+			d.must.have.property('host');
+			d.must.have.property('time');
+			d.value.must.equal(4);
+			mockUDPServer.removeListener('received', observer);
+			done();
+		}
+
+		mockUDPServer.on('received', observer);
+		var emitter = new Emitter(mockUDPOpts);
+		emitter.connect();
+		emitter.metric({ name: 'test', value: 4 });
+	});
+
+	after(function(done)
+	{
+		mockUDPServer.close();
+		done();
+	});
+});

--- a/test/07-nsq.js
+++ b/test/07-nsq.js
@@ -39,11 +39,11 @@ describe('nsq output', function()
 		emitter.connect();
 	});
 
-	it('writes event objects to its socket over udp', function(done)
+	it('writes event objects by posting to http', function(done)
 	{
 		server.once('metric', function handleIncoming(req)
 		{
-			req.url.must.equal('/put?topic=numbat');
+			req.url.must.equal('/pub?topic=numbat');
 			done();
 		});
 

--- a/test/07-nsq.js
+++ b/test/07-nsq.js
@@ -1,0 +1,60 @@
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
+'use strict';
+
+var
+	demand     = require('must'),
+	http       = require('http'),
+	Emitter    = require('../index')
+	;
+
+describe('nsq output', function()
+{
+	var mockNSQOpts = {
+		uri: 'nsq://localhost:4334',
+		topic: 'numbat',
+	};
+
+	var server;
+
+	before(function(done)
+	{
+		server = http.createServer((req, res) =>
+		{
+			server.emit('metric', req);
+			res.end();
+		});
+		server.listen(4334, done);
+	});
+
+	it('can construct an NSQ emitter', function(done)
+	{
+		var emitter = new Emitter(mockNSQOpts);
+		emitter.on('ready', function()
+		{
+			emitter.client.constructor.name.must.equal('NSQStream');
+			emitter.client.must.have.property('_write');
+			emitter.client._write.must.be.a.function();
+			done();
+		});
+		emitter.connect();
+	});
+
+	it('writes event objects to its socket over udp', function(done)
+	{
+		server.once('metric', function handleIncoming(req)
+		{
+			req.url.must.equal('/put?topic=numbat');
+			done();
+		});
+
+		var emitter = new Emitter(mockNSQOpts);
+		emitter.connect();
+		emitter.metric({ name: 'test', value: 4 });
+	});
+
+	after(function(done)
+	{
+		server.close();
+		done();
+	});
+});


### PR DESCRIPTION
Give a uri of `nsq://localhost:4151` to post metrics to an nsq topic. The topic name defaults to `metrics` but can be specified in the options.

Broke tests out into separate files.

BREAKING: removed the host/port options support. You now have to pass a uri-formatted uri field. This will require a major-number bump.