### PR TITLE
_write doesnt like args in its callback

### DIFF
--- a/lib/nsq-stream.js
+++ b/lib/nsq-stream.js
@@ -28,6 +28,6 @@ module.exports = class NSQStream extends stream.Writable
 
 	_write(event, encoding, callback)
 	{
-		this.client.publish(this.topic, JSON.parse(event)).then(callback, callback);
+		this.client.publish(this.topic, JSON.parse(event)).then(() => callback()).catch(callback);
 	}
 };


### PR DESCRIPTION
the previous code was interpreting success as an error and kersploding. this no longer does that.