### PR TITLE
feat: support all the statsd metric types

### DIFF
--- a/test/08-to-statsd.js
+++ b/test/08-to-statsd.js
@@ -10,20 +10,30 @@ describe('toStatsd', function()
 	{
 		const messages = [
 			{ name: 'simple.event' },
+			{ name: 'simple.count', count: 37 },
+			{ name: 'sampling.count', count: 37, rate: 0.1 },
 			{ name: 'simple.value', value: 42 },
 			{ name: 'empty.value', value: 0 },
 			{ name: 'extra.data', value: 47, section: 31 },
 			{ name: 'dirty.tag', ' |-|4c|< 3|2 ': true },
-			{ name: 'multi.tag', value: 34, multi: 'pass', meat: 'popsickle', elements: 5 }
+			{ name: 'multi.tag', value: 34, multi: 'pass', meat: 'popsickle', elements: 5 },
+			{ name: 'timing.value', timing: 666 },
+			{ name: 'set.value', set: 45 },
+			{ name: 'garbage.value', value: 43, other: ['garbage'], ignored: new Date() }
 		];
 
 		const stats = [
 			'simple.event:1|c',
+			'simple.count:37|c',
+			'sampling.count:37|c|@0.1',
 			'simple.value:42|g',
 			'empty.value:0|g',
 			'extra.data:47|g|#section:31',
 			'dirty.tag:1|c|#____4c___3_2_:true',
-			'multi.tag:34|g|#multi:pass,meat:popsickle,elements:5'
+			'multi.tag:34|g|#multi:pass,meat:popsickle,elements:5',
+			'timing.value:666|ms',
+			'set.value:45|s',
+			'garbage.value:43|g'
 		];
 
 		messages.forEach((msg, idx) =>

--- a/to-statsd.js
+++ b/to-statsd.js
@@ -2,25 +2,50 @@
 
 module.exports = function messageToStatsd(message)
 {
-	const { name, value } = message;
+	const { name, rate } = message;
 
 	const tags = Object.keys(message).map(key =>
 	{
-		if (key.match(/(time|value|name)/)) return '';
+		if (key.match(/(time|value|name|timing|set|count|rate)/)) return '';
 		const val = message[key];
 		if (!val || val instanceof Object) return ''; // only want strings, nums, or bools
 		return `${sanitizeTag(key)}:${val}`;
 	}).filter(Boolean);
 	const tagStr = tags.join(',');
 
-	const type = value == null ? 'c' : 'g';
-	let stat = `${name}:${value == null ? 1 : value}|${type}`;
+	const type = getType(message);
+	const value = getValue(message);
+	let stat = `${name}:${value}|${type}`;
+	if (rate != null && type === 'c')
+	{
+		stat += `|@${rate}`;
+	}
 	if (tagStr.length !== 0)
 	{
 		stat += `|#${tagStr}`;
 	}
 	return stat;
 };
+
+function getType(message)
+{
+	const { value, set, timing, count } = message;
+	if (value != null) return 'g';
+	if (count != null) return 'c';
+	if (timing != null) return 'ms';
+	if (set != null) return 's';
+	return 'c';
+}
+
+function getValue(message)
+{
+	const { value, set, timing, count } = message;
+	if (value != null) return value;
+	if (count != null) return count;
+	if (timing != null) return timing;
+	if (set != null) return set;
+	return 1;
+}
 
 function sanitizeTag(input)
 {


### PR DESCRIPTION
This adds supports to the other 2 flavors of statsd metrics, as well as sampling rates, and explicit counts.

Would love some feedback on whether this is the right API (i.e. key names) to express these types.